### PR TITLE
remove duplicate lockerdome adapter

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -5,6 +5,7 @@
     "audienceNetworkBidAdapter",
     "beachfrontBidAdapter",
     "consentManagement",
+    "consumableBidAdapter",
     "conversantBidAdapter",
     "coxBidAdapter",
     "criteoBidAdapter",
@@ -27,6 +28,5 @@
     "smartyadsBidAdapter",
     "sonobiBidAdapter",
     "sovrnBidAdapter",
-    "zeroIdBidAdapter",
-    "consumableBidAdapter"
+    "zeroIdBidAdapter"
 ]

--- a/modules.json
+++ b/modules.json
@@ -28,6 +28,5 @@
     "sonobiBidAdapter",
     "sovrnBidAdapter",
     "zeroIdBidAdapter",
-    "lockerdomeBidAdapter",
     "consumableBidAdapter"
 ]


### PR DESCRIPTION
"lockerdomeBidAdapter" was listed twice in modules.json. This PR removes one of them.