### PR TITLE
CACTUS-21 - Sortable adapter update

### DIFF
--- a/modules/sortableBidAdapter.js
+++ b/modules/sortableBidAdapter.js
@@ -227,6 +227,7 @@ export const spec = {
           rv.ext[partner] = params;
         });
       }
+      rv.ext.gpid = deepAccess(bid, 'ortb2Imp.ext.data.pbadslot');
       return rv;
     });
     const gdprConsent = bidderRequest && bidderRequest.gdprConsent;


### PR DESCRIPTION
**CACTUS-21**
### Summary
For Cactus to get the `gpid` the Prebid Sortable module must be updated. 

### Acceptance Criteria
- Prebid.js updated and deployed to production (5.17.1)
- Pubfig.js update to use new Prebid.js deployment (5.17.1)
- [Test URL](https://webdesignledger.com/?fsaltconfig=283)