### PR TITLE
PFG-1337: ADD sizeMapping to filter video bidders to the ones we support

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -53,5 +53,6 @@
     "yahoosspBidAdapter",
     "yieldmoBidAdapter",
     "ttdBidAdapter",
-    "adyoulikeBidAdapter"
+    "adyoulikeBidAdapter",
+    "sizeMappingV2"
 ]


### PR DESCRIPTION
Adding a new module that allows to filter bidders based on mediaType defined in config.