### PR TITLE
PFG-2244 Removed intentIQ module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -21,7 +21,6 @@
     "hadronIdSystem",
     "hadronRtdProvider",
     "identityLinkIdSystem",
-    "intentIqIdSystem",
     "ixBidAdapter",
     "justpremiumBidAdapter",
     "kargoBidAdapter",


### PR DESCRIPTION
https://freestar.atlassian.net/browse/PFG-2244

The IIQ module in Prebid.js is no longer required for Pubfig. We need to remove the IIQ module from Prebid.js

Removed intentIqIdSystem from the modules list.