### PR TITLE
fix: remove PubCommon from modules

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -29,7 +29,6 @@
     "openxBidAdapter",
     "permutiveRtdProvider",
     "prebidServerBidAdapter",
-    "pubCommonId",
     "pubmaticBidAdapter",
     "pubProvidedIdSystem",
     "priceFloors",


### PR DESCRIPTION
[S2S-1390](https://freestar.atlassian.net/browse/S2S-1390)

Removing the PubCommonId module as it's been merged with SharedID and should no longer be used. 

[S2S-1390]: https://freestar.atlassian.net/browse/S2S-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ