### PR TITLE
fix: PFG-3233. Increasing minimum timeout to be not less than 1500 ms.

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -67,9 +67,7 @@ export function fetcherFactory(timeout = 3000, {request, done} = {}) {
   let fetcher = (resource, options) => {
     let to;
     if (timeout != null && options?.signal == null && !config.getConfig('disableAjaxTimeout')) {
-      const minTimout = 1500;
-      const normalizedTimeout = timeout > minTimout ? timeout : minTimout;
-      to = dep.timeout(normalizedTimeout, resource);
+      to = dep.timeout(timeout, resource);
       options = Object.assign({signal: to.signal}, options);
     }
     let pm = dep.fetch(resource, options);

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -67,7 +67,9 @@ export function fetcherFactory(timeout = 3000, {request, done} = {}) {
   let fetcher = (resource, options) => {
     let to;
     if (timeout != null && options?.signal == null && !config.getConfig('disableAjaxTimeout')) {
-      to = dep.timeout(timeout, resource);
+      const minTimout = 1500;
+      const normalizedTimeout = timeout > minTimout ? timeout : minTimout;
+      to = dep.timeout(normalizedTimeout, resource);
       options = Object.assign({signal: to.signal}, options);
     }
     let pm = dep.fetch(resource, options);

--- a/src/auction.js
+++ b/src/auction.js
@@ -125,6 +125,14 @@ export function resetAuctionState() {
   queuedCalls.length = 0;
   [outstandingRequests, sourceInfo].forEach((ob) => Object.keys(ob).forEach((k) => { delete ob[k] }));
 }
+/**
+ * Normalize custom timeout to be not less than 1500 ms
+ * @param timeout
+ * @returns {number}
+ */
+function normalizeCbTimeout (timeout) {
+  return Math.max(timeout, 1500);
+}
 
 /**
  * Creates new auction instance
@@ -147,7 +155,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
   const _labels = labels;
   const _adUnitCodes = adUnitCodes;
   const _auctionId = auctionId || generateUUID();
-  const _timeout = cbTimeout;
+  const _timeout = normalizeCbTimeout(cbTimeout);
   const _timelyRequests = new Set();
   const done = defer();
   let _bidsRejected = [];


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
