### PR TITLE
fix: [PFG-3188] Fix circular reference error in adapters

### DIFF
--- a/modules/carbonAnalyticsAdapter.js
+++ b/modules/carbonAnalyticsAdapter.js
@@ -1,4 +1,4 @@
-import { deepAccess, generateUUID, logError } from '../src/utils.js';
+import { cloneEventArguments, deepAccess, generateUUID, logError } from '../src/utils.js';
 import { ajax } from '../src/ajax.js';
 import { getStorageManager } from '../src/storageManager.js';
 import {getGlobal} from '../src/prebidGlobal.js';
@@ -31,7 +31,8 @@ let timeLastAuctionEvent = null;
 
 export let carbonAdapter = Object.assign(adapter({analyticsHost, ANALYTICS_TYPE}), {
   track({eventType, args}) {
-    args = args ? JSON.parse(JSON.stringify(args)) : {};
+    args = cloneEventArguments(args || {});
+
     switch (eventType) {
       case EVENTS.AUCTION_END: {
         registerEngagement();

--- a/modules/hadronAnalyticsAdapter.js
+++ b/modules/hadronAnalyticsAdapter.js
@@ -53,7 +53,8 @@ let analyticsType = 'endpoint';
 
 let hadronAnalyticsAdapter = Object.assign(adapter({url: HADRON_ANALYTICS_URL, analyticsType}), {
   track({eventType, args}) {
-    args = args ? JSON.parse(JSON.stringify(args)) : {};
+    args = utils.cloneEventArguments(args || {});
+
     var data = {};
     if (!eventsToTrack.includes(eventType)) return;
     switch (eventType) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "8.49.5",
+  "version": "8.49.6",
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "scripts": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1083,3 +1083,29 @@ export function binarySearch(arr, el, key = (el) => el) {
   }
   return left;
 }
+
+const skipPatterns = [
+  /^\[object HTML.*]$/,
+  /^\[object Window.*]$/
+]
+
+export function cloneEventArguments(args) {
+  try {
+    return JSON.parse(
+      JSON.stringify(
+        args,
+        // When data has a reference to window or any html elements
+        // JSON.stringify fails with TypeError: Converting circular structure to JSON
+        // replacer function below excludes referenced html elements
+        (_key, value) => {
+          if (skipPatterns.some(pattern => pattern.test(String(value))) || typeof value === 'function') {
+            return undefined;
+          }
+          return value;
+        },
+      ),
+    );
+  } catch (e) {
+    return args;
+  }
+}


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
[PFG-3188](https://freestar.atlassian.net/browse/PFG-3188)

Fixed error: `Converting circular structure to JSON` - that is caused by rare cases when DOM nodes are provided in event arguments/payload.
This fix removes those nodes while cloning the arguments. 

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->


[PFG-3188]: https://freestar.atlassian.net/browse/PFG-3188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ