### PR TITLE
[PFG-3342] fix: normalize promise now have the ability to treat errors properly

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -1041,11 +1041,19 @@ export function attachIdSystem(submodule) {
   }
 }
 
-function normalizePromise(fn) {
+function normalizePromise(fn, handleErrors = false, fnName) {
   // for public methods that return promises, make sure we return a "normal" one - to avoid
   // exposing confusing stack traces
   return function() {
-    return Promise.resolve(fn.apply(this, arguments));
+    const promise = Promise.resolve(fn.apply(this, arguments));
+
+    if (handleErrors) {
+      return promise.catch(error => {
+        logWarn(`Error occurred in ${fnName}: ${error.message || error}`);
+      });
+    }
+
+    return promise;
   }
 }
 
@@ -1088,7 +1096,7 @@ export function init(config, {delay = GreedyPromise.timeout} = {}) {
   (getGlobal()).getUserIdsAsEids = getUserIdsAsEids;
   (getGlobal()).getEncryptedEidsForSource = normalizePromise(getEncryptedEidsForSource);
   (getGlobal()).registerSignalSources = registerSignalSources;
-  (getGlobal()).refreshUserIds = normalizePromise(refreshUserIds);
+  (getGlobal()).refreshUserIds = normalizePromise(refreshUserIds, true, 'refreshUserIds');
   (getGlobal()).getUserIdsAsync = normalizePromise(getUserIdsAsync);
   (getGlobal()).getUserIdsAsEidBySource = getUserIdsAsEidBySource;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "8.49.8",
+  "version": "8.49.81",
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "scripts": {


### PR DESCRIPTION
Description:
The normalizePromise is throwing uncaught errors in console and this have been an issue for a publisher. This PR goal is to only handle the promise error since it is a good pratice to do so. Also, for this function is normal to sometimes it to throw. We want though to investigate a little bit more, this is mean't to be only a hotfix.  It's still possible to see the error by adding to the url pbjs_debug=true.

[PFG-3342](https://freestar.atlassian.net/browse/PFG-3342)

[PFG-3342]: https://freestar.atlassian.net/browse/PFG-3342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ