### PR TITLE
fix: [PFG-3342] add callback to identityLinkIdSystem

### DIFF
--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -132,6 +132,8 @@ function getEnvelope(url, callback, configParams) {
     utils.logInfo('identityLink: A 3P retrieval is attempted!');
     setEnvelopeSource(false);
     ajax(url, callbacks, undefined, { method: 'GET', withCredentials: true });
+  } else {
+    callback()
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "8.49.81",
+  "version": "8.49.82",
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "scripts": {


### PR DESCRIPTION
[PFG-3342](https://freestar.atlassian.net/browse/PFG-3342)

Currently, when refreshing identityLink, if it was previously refreshed, a cookie is set that prevents another request until the cookie expires. While this behavior is expected, the callback that signals userSync to continue refreshing the other submodules never gets triggered, disrupting the entire flow. As a result, other submodules are not refreshed as intended.

Solution:
As an immediate solution, we execute the callback even when the request doesn't go through. This ensures the flow continues, and identityLink uses the previously set ID. Note that a separate PR is being made for Prebid to address original repository.

[PFG-3342]: https://freestar.atlassian.net/browse/PFG-3342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ