### PR TITLE
[PFG-3394] feat: add pulsepoint adapter

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -58,5 +58,7 @@
     "vidazooBidAdapter",
     "videojsVideoProvider",
     "yahoosspBidAdapter",
-    "yieldmoBidAdapter"
+    "yieldmoBidAdapter",
+    "pulsepointBidAdapter",
+    "pulsepointAnalyticsAdapter"
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "8.49.83",
+  "version": "8.49.84",
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "scripts": {


### PR DESCRIPTION
## Description, Motivation and Context
We want to add pulsepoint adapter to prebid.js build to avoid discrepancies.
**[PFG-3394](https://freestar.atlassian.net/browse/PFG-3394)**


[PFG-3394]: https://freestar.atlassian.net/browse/PFG-3394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ