### PR TITLE
S2S-2232: enable gamera rtd module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -58,5 +58,6 @@
     "yahooAdsBidAdapter",
     "yieldmoBidAdapter",
     "pulsepointBidAdapter",
-    "sovrnBidAdapter"
+    "sovrnBidAdapter",
+    "gameraRtdProvider"
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "9.22.0",
+  "version": "9.23.0",
   "description": "Header Bidding Management Library",
   "main": "src/prebid.public.js",
   "exports": {


### PR DESCRIPTION
## Description of change
<!-- Describe the change proposed in this pull request -->
Enabled Gamera RTD module
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
