### PR TITLE
fix: PFG-4126: Respect relevantMediaTypes in client side ttd bid requests

### DIFF
--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -172,7 +172,8 @@ function getImpression(bidRequest) {
   const secure = utils.deepAccess(bidRequest, 'ortb2Imp.secure');
   impression.secure = isNumber(secure) ? secure : 1
 
-  utils.mergeDeep(impression, bidRequest.ortb2Imp)
+  const {video: _, ...ortb2ImplWithoutVideo} = bidRequest.ortb2Imp; // if enabled, video is already assigned above
+  utils.mergeDeep(impression, ortb2ImplWithoutVideo)
 
   return impression;
 }

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -172,8 +172,8 @@ function getImpression(bidRequest) {
   const secure = utils.deepAccess(bidRequest, 'ortb2Imp.secure');
   impression.secure = isNumber(secure) ? secure : 1
 
-  const {video: _, ...ortb2ImplWithoutVideo} = bidRequest.ortb2Imp; // if enabled, video is already assigned above
-  utils.mergeDeep(impression, ortb2ImplWithoutVideo)
+  const {video: _, ...ortb2ImpWithoutVideo} = bidRequest.ortb2Imp; // if enabled, video is already assigned above
+  utils.mergeDeep(impression, ortb2ImpWithoutVideo)
 
   return impression;
 }


### PR DESCRIPTION
## Description
Since [Prebid 9.23.0](https://github.com/prebid/Prebid.js/releases/tag/9.23.0) if ad unit has `mediaType` `video`, video prop is appended to  ad units `ortb2Imp` object: https://github.com/prebid/Prebid.js/blob/master/src/prebid.js#L114-L148

When ad unit has `video` `mediaType` configured  on ad unit level but ttd does not have video enabled on bidder level for that ad unit (passed in `relevantMediatypes`): 
ttd adapter is appending all adUnit ortb2Imp fields to the bid request causing video being requested even when it is disabled on bidder level.

## References
PR with ortb params sync: https://github.com/prebid/Prebid.js/pull/12423