### PR TITLE
bidResponseFilter: read mediaType from bid, not bid.meta

### DIFF
--- a/modules/bidResponseFilter/index.js
+++ b/modules/bidResponseFilter/index.js
@@ -39,11 +39,13 @@ export function addBidResponseHook(next, adUnitCode, bid, reject, index = auctio
   const mediaTypesConfig = {enforce: true, blockUnknown: true, ...(moduleConfig?.mediaTypes || {})};
 
   const {
-    primaryCatId, secondaryCatIds = [],
-    advertiserDomains = [],
-    attr: metaAttr,
     mediaType: metaMediaType,
-  } = bid.meta || {};
+    meta: {
+      primaryCatId, secondaryCatIds = [],
+      advertiserDomains = [],
+      attr: metaAttr
+    } = {}
+  } = bid;
 
   // checking if bid fulfills ortb2 fields rules
   if ((catConfig.enforce && bcat.some(category => [primaryCatId, ...secondaryCatIds].includes(category))) ||

--- a/test/spec/modules/bidResponseFilter_spec.js
+++ b/test/spec/modules/bidResponseFilter_spec.js
@@ -65,11 +65,11 @@ describe('bidResponseFilter', () => {
     })
 
     const bid = {
+      mediaType: 'banner',
       meta: {
         advertiserDomains: ['domain1.com', 'domain2.com'],
         primaryCatId: 'EXAMPLE-CAT-ID',
         attr: 'attr',
-        mediaType: 'banner'
       }
     };
 
@@ -118,12 +118,12 @@ describe('bidResponseFilter', () => {
     const reject = sinon.stub();
     const call = sinon.stub();
     const bid = {
+      mediaType: 'video',
       meta: {
         advertiserDomains: ['validdomain1.com', 'validdomain2.com'],
         primaryCatId: 'VALID_CAT',
         attr: 'BANNED_ATTR'
       },
-      mediaType: 'video'
     };
     mockAuctionIndex.getOrtb2 = () => ({
       badv: ['domain2.com'], bcat: ['BANNED_CAT1', 'BANNED_CAT2']
@@ -144,11 +144,11 @@ describe('bidResponseFilter', () => {
   it('should omit the validation if the flag is set to false', () => {
     const call = sinon.stub();
     const bid = {
+      mediaType: 'banner',
       meta: {
         advertiserDomains: ['validdomain1.com', 'validdomain2.com'],
         primaryCatId: 'BANNED_CAT1',
         attr: 'valid_attr',
-        mediaType: 'banner',
       }
     };
 
@@ -173,11 +173,11 @@ describe('bidResponseFilter', () => {
   it('should allow bid for unknown flag set to false', () => {
     const call = sinon.stub();
     const bid = {
+      mediaType: 'banner',
       meta: {
         advertiserDomains: ['validdomain1.com', 'validdomain2.com'],
         primaryCatId: undefined,
         attr: 'valid_attr',
-        mediaType: 'banner'
       }
     };
 
@@ -203,11 +203,11 @@ describe('bidResponseFilter', () => {
     const reject = sinon.stub();
     const call = sinon.stub();
     const bid = {
+      mediaType: 'audio',
       meta: {
         advertiserDomains: ['validdomain1.com', 'validdomain2.com'],
         primaryCatId: 'VALID_CAT',
         attr: 6,
-        mediaType: 'audio'
       },
     };
 


### PR DESCRIPTION
`bidResponseFilter` reads `mediaType` from `bid.meta`, but `mediaType` is defined on `bid` level. As result valid bids are rejected when `mediaType` enforcement is enabled.
<img width="811" height="542" alt="Screenshot 2026-02-05 at 11 44 32" src="https://github.com/user-attachments/assets/df8f717c-5564-438a-9d7b-679e3257140b" />
