### PR TITLE
Set phoenix-rising as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,1 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @freestarcapital/phoenix will be requested for
-# review when someone opens a pull request.
-*       @freestarcapital/phoenix
+* @freestarcapital/phoenix-rising


### PR DESCRIPTION
Sets root CODEOWNERS to `* @freestarcapital/phoenix-rising` per the repo-ownership audit (PLAT-1585).