### PR TITLE
chore: add Terraform CODEOWNERS rule

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @freestarcapital/phoenix-rising
+*.tf   @freestarcapital/platform


### PR DESCRIPTION
Adds the standing rule `*.tf @freestarcapital/platform` per PLAT-1592.

Part of the GitHub Governance rollout (PLAT-1484).